### PR TITLE
protocol relative URL for sitelink in config.js

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,7 +2,7 @@
 
 var ffmapConfig = {
   // link to your main community site:
-  url:       "http://bremen.freifunk.net/",
+  url:       "//bremen.freifunk.net/",
 
   // visible link in the navigation:
   sitename:  "bremen.freifunk.net",


### PR DESCRIPTION
Changing sitelink in config.js to enable protocol relative URLs (http/https). This change is not really needed, because all URLs are written directly into the HTML-files in this fork. So this is just to have it nice and clean.
